### PR TITLE
Adding selectorFilter option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const maybe = fn => {
 	}
 };
 
-module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags = {}}) => {
+module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags = {}, selectorFilter}) => {
 	const $ = cheerio.load(html);
 	let preserve = false;
 
@@ -25,7 +25,10 @@ module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags =
 				}
 
 				if (node.selector && !node.selector.match(/:(?:not)/)) {
-					const selector = node.selector.replace(/::?[\w-]+/g, '');
+					let selector = node.selector.replace(/::?[\w-]+/g, '');
+					if (selectorFilter) {
+						selector = selectorFilter(selector);
+					}
 					if (maybe(() => $(selector).length === 0)) {
 						node.remove();
 					}

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ function renderCss(css, html, hasLazyLoad) {
 
 ### `selectorFilter`
 
-the `selectorFilter` option can be used to filter modifier classes, which may not be in the HTML when postcss is run, from selectors. in the example below, the `.tooltip.open .tooltip-tip` block would normally be discarded. but by filtering the `.open` modifier from it's selector, ensures it is kept.
+the `selectorFilter` option can be used to filter modifier classes, which may not be in the HTML when postcss is run, from selectors. in the example below, the `.tooltip.open .tooltip-tip` block would normally be discarded; but filtering the `.open` modifier from it's selector, ensures it is kept.
 
 ```css
 .tooltip .tooltip-tip {

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ function renderCss(css, html, hasLazyLoad) {
 
 ### `selectorFilter`
 
-the `selectorFilter` option can be used to filter modifier classes from selectors.
+the `selectorFilter` option can be used to filter modifier classes, which may not be in the HTML when postcss is run, from selectors. in the example below, the `.tooltip.open .tooltip-tip` block would normally be discarded. but by filtering the `.open` modifier from it's selector, ensures it is kept.
 
 ```css
 .tooltip .tooltip-tip {

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,31 @@ function renderCss(css, html, hasLazyLoad) {
 }
 ```
 
+### `selectorFilter`
+
+the `selectorFilter` option can be used to filter modifier classes from selectors.
+
+```css
+.tooltip .tooltip-tip {
+	display: none;
+}
+.tooltip.open .tooltip-tip {
+	display: block;
+}
+```
+
+```js
+ require('postcss');
+const removeUnused = require('postcss-remove-unused');
+
+postcss([
+	removeUnused({
+		html: '<div class="tooltip><span class="tooltip-target">term</span><div class="tooltip-tip">Term definition</div></div>',
+		selectorFilter: selector => selector.replace(/(\.tooltip)\.open/g, '$1'),
+	})
+]).process(css);
+```
+
 ## prior art
 
 postcss-remove-unused is heavily inspired by [uncss](https://github.com/giakki/uncss). there's a few major differences:

--- a/test.js
+++ b/test.js
@@ -154,5 +154,32 @@ module.exports = {
 /* pru:endPreserve(bar) */
 `);
 		}
+	},
+
+	selectorFilter: {
+		'should keep a selector that would otherwise not be kept'() {
+			expect(
+				process(`
+.foo {
+	color: blue;
+}
+
+.foo.bar {
+	color: red;
+}
+`,
+					'<div class="foo"></div>',
+					{selectorFilter: selector => selector.replace(/(\.foo)\.bar/g, '$1')}
+				)
+			).to.equal(`
+.foo {
+	color: blue;
+}
+
+.foo.bar {
+	color: red;
+}
+`);
+		}
 	}
 };


### PR DESCRIPTION
This change allows users to modify selectors before they are checked against the HTML. The primary use case for this is to keep modifier classes that may not be in the HTML when postcss is run.

See my changes to the README for an example.