### PR TITLE
Smarter handling for :not selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const maybe = fn => {
 module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags = {}, selectorFilter}) => {
 	const $ = cheerio.load(html);
 	let preserve = false;
+	const PSEUDO_SELECTOR_RE = /([^:\\])::?[\w-]+(?:\(.*?\))?([,\s]|$)/g;
 
 	return css => css.walk(node => {
 		switch (node.type) {
@@ -24,8 +25,8 @@ module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags =
 					return;
 				}
 
-				if (node.selector && !node.selector.match(/:(?:not)/)) {
-					let selector = node.selector.replace(/::?[\w-]+/g, '');
+				if (node.selector && !/(?:^|[,])\s*:not/.test(node.selector)) {
+					let selector = node.selector.replace(PSEUDO_SELECTOR_RE, '$1$2');
 					if (selectorFilter) {
 						selector = selectorFilter(selector);
 					}

--- a/index.js
+++ b/index.js
@@ -12,16 +12,17 @@ const maybe = fn => {
 module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags = {}, selectorFilter}) => {
 	const $ = cheerio.load(html);
 	let preserve = false;
-	// Matches a standalone, or unqualified, `:not` selector.
+	// Matches for selectors that contain standalone `:not()` selectors.
 	//     **matches**
-	//         :not
-	//         .foo, :not
+	//         :not(.foo)
+	//         .foo(.foo), :not(.foo)
+	//         .bar, :not(.foo), .baz
 	//     **doesn't match**
-	//         .bar:not
-	//         .bar :not
-	//         :not .bar
-	const STANDALONE_NOT_SELECTOR_RE = /(?:^|,)\s*:not/;
-	// Matches pseudo-selectors, with a negative-look behind like capture group to prevent matching
+	//         .bar:not(.foo)
+	//         .bar :not(.foo)
+	//         :not(.foo) .bar
+	const STANDALONE_NOT_SELECTOR_RE = /(?:^|,)\s*:not\s*\(.*?\)\s*(?:$|,)/;
+	// Matches pseudo-selectors, with a negative-look behind **like** capture group to prevent matching
 	// escaped colons.
 	//     **matches**
 	//         :first-child:hover

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const maybe = fn => {
 module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags = {}, selectorFilter}) => {
 	const $ = cheerio.load(html);
 	let preserve = false;
-	const PSEUDO_SELECTOR_RE = /([^:\\])::?[\w-]+(?:\(.*?\))?([,\s]|$)/g;
+	const PSEUDO_SELECTOR_RE = /([^:\\])(?:::?[\w-]+(?:\(.*?\))?)+/g;
 
 	return css => css.walk(node => {
 		switch (node.type) {
@@ -26,7 +26,7 @@ module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags =
 				}
 
 				if (node.selector && !/(?:^|[,])\s*:not/.test(node.selector)) {
-					let selector = node.selector.replace(PSEUDO_SELECTOR_RE, '$1$2');
+					let selector = node.selector.replace(PSEUDO_SELECTOR_RE, '$1');
 					if (selectorFilter) {
 						selector = selectorFilter(selector);
 					}

--- a/test.js
+++ b/test.js
@@ -86,6 +86,9 @@ module.exports = {
 .foo:not(.bar) a {
 	color: blue;
 }
+.foo:not(.bar) a,.blarg:not(.bar) {
+	color: blue;
+}
 `,
 				'<div id="bing"><div class="foo bar"><span></span></div></div>'
 			)
@@ -111,6 +114,9 @@ module.exports = {
 
 .bar::before {
 	color: red;
+}
+.bar:nth-child(2n+1) {
+	color: gray;
 }
 `,
 				'<div class="foo"></div>'

--- a/test.js
+++ b/test.js
@@ -43,18 +43,61 @@ module.exports = {
 `);
 	},
 
-	'should leave :not() intact'() {
+	'should leave unqualified :not() intact'() {
 		expect(
 			process(`
-.foo:not(.bar) {
-	color: red;
+:not(.bar) {
+	color: blue;
+}
+:not(.baz) {
+	color: green;
 }
 `,
 				'<div class="foo bar"></div>'
 			)
 		).to.equal(`
+:not(.bar) {
+	color: blue;
+}
+:not(.baz) {
+	color: green;
+}
+`);
+	},
+
+	'should test qualified :not() selectors, ignoring the :not()'() {
+		expect(
+			process(`
 .foo:not(.bar) {
+	color: blue;
+}
+.baz:not(.foo) {
 	color: red;
+}
+#bing .foo:not(.bar) {
+	color: green;
+}
+#bing .foo:not(.bar) a {
+	color: gray;
+}
+#bing .foo:not(.bar) span {
+	color: yellow;
+}
+.foo:not(.bar) a {
+	color: blue;
+}
+`,
+				'<div id="bing"><div class="foo bar"><span></span></div></div>'
+			)
+		).to.equal(`
+.foo:not(.bar) {
+	color: blue;
+}
+#bing .foo:not(.bar) {
+	color: green;
+}
+#bing .foo:not(.bar) span {
+	color: yellow;
 }
 `);
 	},
@@ -94,6 +137,50 @@ module.exports = {
 			)
 		).to.equal(`
 .foo:first-child {
+	color: blue;
+}
+`);
+	},
+
+	'should work with attribute selectors'() {
+		expect(
+			process(`
+[title] {
+	color: blue;
+}
+[name] {
+	color: red;
+}
+.foo[title] {
+	color: green;
+}
+`,
+				'<div class="foo" title="baz"></div>'
+			)
+		).to.equal(`
+[title] {
+	color: blue;
+}
+.foo[title] {
+	color: green;
+}
+`);
+	},
+
+	'should work with attribute selectors containing a ":"'() {
+		expect(
+			process(`
+[foo\\:bar] {
+	color: blue;
+}
+[foo\\:baz] {
+	color: red;
+}
+`,
+				'<div foo:bar></div>'
+			)
+		).to.equal(`
+[foo\\:bar] {
 	color: blue;
 }
 `);

--- a/test.js
+++ b/test.js
@@ -122,6 +122,25 @@ module.exports = {
 `);
 	},
 
+	'should test double pseudoelements based on their parent'() {
+		expect(
+			process(`
+.foo::hover::before {
+	color: blue;
+}
+.bar::hover::before {
+	color: red;
+}
+`,
+				'<div class="foo"></div>'
+			)
+		).to.equal(`
+.foo::hover::before {
+	color: blue;
+}
+`);
+	},
+
 	'should test pseudoclasses based on their parent'() {
 		expect(
 			process(`

--- a/test.js
+++ b/test.js
@@ -89,6 +89,12 @@ module.exports = {
 .foo:not(.bar) a,.blarg:not(.bar) {
 	color: blue;
 }
+:not(.bar) .foo {
+	color: blue;
+}
+:not(.bar) a {
+	color: blue;
+}
 `,
 				'<div id="bing"><div class="foo bar"><span></span></div></div>'
 			)
@@ -101,6 +107,9 @@ module.exports = {
 }
 #bing .foo:not(.bar) span {
 	color: yellow;
+}
+:not(.bar) .foo {
+	color: blue;
 }
 `);
 	},


### PR DESCRIPTION
Rather than keeping all selectors that contain `:not` pseudo selectors, this change just ignores them when they are qualified. This works because removing the `:not` from a selector will only make it more inclusive. Another way of saying it is that adding `:not` to a selector will only reduce the number of elements it will apply to.

The updated regex is also a bit more strict about what it removes. For instance, before this change an attribute selector containing a ":" like `[ng\:cloak]` would get munged to `[ng\]`. The updated selector only matches `:` characters that are not preceded by a `\`.