### PR TITLE
remove unused selectors from comma-separated rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags =
 				}
 
 				if (node.selector) {
-					let usedSelectors = [];
+					const usedSelectors = [];
 					// iterate over each selector in a rule to see if it is used
 					node.selector.split(',').forEach(s => {
 						if (STANDALONE_NOT_SELECTOR_RE.test(s)) {

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = postcss.plugin('postcss-remove-unused', ({html, preserveFlags =
 							if (selectorFilter) {
 								selector = selectorFilter(selector);
 							}
-							if (!maybe(() => $(selector).length === 0)) {
+							if (maybe(() => $(selector).length !== 0)) {
 								usedSelectors.push(s);
 							}
 						}

--- a/test.js
+++ b/test.js
@@ -27,6 +27,22 @@ module.exports = {
 `);
 	},
 
+	'should remove an unused selector from a rule'() {
+		expect(
+			process(`
+.foo, .bar {
+	color: blue;
+}
+`,
+				'<div class="foo"></div>'
+			)
+		).to.equal(`
+.foo {
+	color: blue;
+}
+`);
+	},
+
 	'should leave @keyframes intact'() {
 		expect(
 			process(`


### PR DESCRIPTION
when you have a comma-separated rule like:
```css
.foo, .bar {
    color: red;
}
```
and html like:
```html
<span class='foo'>test</span>
```
That css currently remains untouched. With this change, it will be modified to remove the unused selector in the list. So it would now look like:
```css
.foo {
    color: red;
}
```